### PR TITLE
Backfill missing lab metadata (5 files)

### DIFF
--- a/Instructions/Labs/Complete Guided Exercise-Deploy Applications to AKS.md
+++ b/Instructions/Labs/Complete Guided Exercise-Deploy Applications to AKS.md
@@ -1,7 +1,15 @@
 ---
-Guided Exercise:
-  title: Guided Exercise Deploy Applications to AKS
+lab:
+  title: Guided Exercise - Deploy applications to Azure Kubernetes Service (AKS)
+  description: 'This guided exercise consist of the following activities:'
+  duration: 5 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Kubernetes Service (AKS)
 ---
+
 # Guided Exercise - Deploy applications to Azure Kubernetes Service (AKS)
 
 ## Objectives

--- a/Instructions/Labs/Exercise_01_provision_registry_azure_kubernetes_service.md
+++ b/Instructions/Labs/Exercise_01_provision_registry_azure_kubernetes_service.md
@@ -1,7 +1,13 @@
 ---
-Exercise:
-  title: 'Exercise: Provision Azure Container Registry (ACR) and Azure Kubernetes Service (AKS)'
-  module: Guided Project - Deploy applications to Azure Kubernetes Service
+lab:
+  title: Exercise - Deploy applications to Azure Kubernetes Service (AKS)
+  description: 'This guided project consist of the following exercises:'
+  duration: 5 minutes
+  level: 500
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Kubernetes Service (AKS)
 ---
 
 # Exercise - Deploy applications to Azure Kubernetes Service (AKS)

--- a/Instructions/Labs/Exercise_02_build_linux_windows_container_images.md
+++ b/Instructions/Labs/Exercise_02_build_linux_windows_container_images.md
@@ -1,8 +1,15 @@
 ---
-Exercise:
-  title: 'Exercise: Build Linux and Windows container images and store them in Azure Container Registry'
-  module: Guided Project - Deploy applications to Azure Kubernetes Service
+lab:
+  title: Exercise 2 - Deploy applications to Azure Kubernetes Service (AKS)
+  description: 'This guided project consist of the following exercises:'
+  duration: 5 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Kubernetes Service (AKS)
 ---
+
 # Exercise 2 - Deploy applications to Azure Kubernetes Service (AKS)
 
 ## Objectives

--- a/Instructions/Labs/Exercise_03_deploy_container_images_azure_kubernetes_service.md
+++ b/Instructions/Labs/Exercise_03_deploy_container_images_azure_kubernetes_service.md
@@ -1,8 +1,15 @@
 ---
-Exercise:
-  title: 'Exercise: Deploy container images to Azure Kubernetes Service'
-  module: Guided Project - Deploy applications to Azure Kubernetes Service
+lab:
+  title: Exercise 3 - Deploy applications to Azure Kubernetes Service (AKS)
+  description: 'This guided project consist of the following exercises:'
+  duration: 64 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Kubernetes Service (AKS)
 ---
+
 # Exercise 3 - Deploy applications to Azure Kubernetes Service (AKS)
 
 ## Objectives

--- a/Instructions/Labs/Exercise_04_review_deployment_deprovision.md
+++ b/Instructions/Labs/Exercise_04_review_deployment_deprovision.md
@@ -1,8 +1,15 @@
 ---
-Exercise:
-  title: 'Exercise: Review the deployment and deprovision all resources'
-  module: Guided Project - Deploy applications to Azure Kubernetes Service
+lab:
+  title: Exercise 4 - Deploy applications to Azure Kubernetes Service (AKS)
+  description: 'This guided project consist of the following exercises:'
+  duration: 30 minutes
+  level: 400
+  islab: true
+  primarytopics:
+  - Azure
+  - Azure Kubernetes Service (AKS)
 ---
+
 # Exercise 4 - Deploy applications to Azure Kubernetes Service (AKS)
 
 ## Objectives


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 5

- `Instructions/Labs/Complete Guided Exercise-Deploy Applications to AKS.md` (normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/Exercise_01_provision_registry_azure_kubernetes_service.md` (normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/Exercise_02_build_linux_windows_container_images.md` (normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/Exercise_03_deploy_container_images_azure_kubernetes_service.md` (normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/Exercise_04_review_deployment_deprovision.md` (normalized_case_keys,title,description,duration,level,islab,primarytopics)
