### PR TITLE
Backfill missing lab metadata (4 files)

### DIFF
--- a/Instructions/Labs/Exercise_01_provision_registry_azure_kubernetes_service.md
+++ b/Instructions/Labs/Exercise_01_provision_registry_azure_kubernetes_service.md
@@ -2,6 +2,14 @@
 Exercise:
   title: 'Exercise: Provision Azure Container Registry (ACR) and Azure Kubernetes Service (AKS)'
   module: Guided Project - Deploy applications to Azure Kubernetes Service
+  description: In this exercise, you will create an Azure Container registry and an AKS cluster.
+  duration: 5 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Container Registry
+    - Azure Kubernetes Service (AKS)
 ---
 
 # Exercise - Deploy applications to Azure Kubernetes Service (AKS)

--- a/Instructions/Labs/Exercise_02_build_linux_windows_container_images.md
+++ b/Instructions/Labs/Exercise_02_build_linux_windows_container_images.md
@@ -2,7 +2,16 @@
 Exercise:
   title: 'Exercise: Build Linux and Windows container images and store them in Azure Container Registry'
   module: Guided Project - Deploy applications to Azure Kubernetes Service
+  description: In this exercise, you will build a Linux- and Windows-based Docker images and pushed them into the Azure Container registry you created earlier in this lab.
+  duration: 5 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Container Registry
+    - Windows
 ---
+
 # Exercise 2 - Deploy applications to Azure Kubernetes Service (AKS)
 
 ## Objectives

--- a/Instructions/Labs/Exercise_03_deploy_container_images_azure_kubernetes_service.md
+++ b/Instructions/Labs/Exercise_03_deploy_container_images_azure_kubernetes_service.md
@@ -2,7 +2,14 @@
 Exercise:
   title: 'Exercise: Deploy container images to Azure Kubernetes Service'
   module: Guided Project - Deploy applications to Azure Kubernetes Service
+  description: In this exercise you deploy container images to Azure Kubernetes Service.
+  duration: 64 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
 ---
+
 # Exercise 3 - Deploy applications to Azure Kubernetes Service (AKS)
 
 ## Objectives

--- a/Instructions/Labs/Exercise_04_review_deployment_deprovision.md
+++ b/Instructions/Labs/Exercise_04_review_deployment_deprovision.md
@@ -2,7 +2,12 @@
 Exercise:
   title: 'Exercise: Review the deployment and deprovision all resources'
   module: Guided Project - Deploy applications to Azure Kubernetes Service
+  description: In this exercise, you will review the results of the deployments and deprovision all resources.
+  duration: 30 minutes
+  level: 400
+  islab: true
 ---
+
 # Exercise 4 - Deploy applications to Azure Kubernetes Service (AKS)
 
 ## Objectives


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 4

- `Instructions/Labs/Exercise_01_provision_registry_azure_kubernetes_service.md` (template_exercise_container,description,duration,level,islab,primarytopics)
- `Instructions/Labs/Exercise_02_build_linux_windows_container_images.md` (template_exercise_container,description,duration,level,islab,primarytopics)
- `Instructions/Labs/Exercise_03_deploy_container_images_azure_kubernetes_service.md` (template_exercise_container,description,duration,level,islab,primarytopics)
- `Instructions/Labs/Exercise_04_review_deployment_deprovision.md` (template_exercise_container,description,duration,level,islab)
